### PR TITLE
Update the same file as the one passed as a parameter

### DIFF
--- a/AppImageUpdate.AppDir/usr/bin/appimageupdate
+++ b/AppImageUpdate.AppDir/usr/bin/appimageupdate
@@ -147,10 +147,10 @@ if [ "$TYPE" == "zsync" ] ; then
   # downloads and reuse the data already downloaded.
   ZSYNC_URL=$(echo "${APPLICATION_USED}" | cut -d "|" -f 2) # Get the URL of the zsync file
   echo "$ZSYNC_URL"
+  ORIG_MOD=$(stat --format '%a' "${ISO}")
   # Get the file with zsync using $1 as an input file
-  zsync_curl -I -i "${ISO}" "${ZSYNC_URL}" 2>&1
-  NEWFILE=$(basename "${ZSYNC_URL}" | sed -e 's|.zsync||g' ) # FIXME: Use the file that zsync has written!!!
-  chmod --reference="${ISO}.zs-old" "$(printf '%b' "${NEWFILE//%/\\x}")" # Set the same permissions as for the original file
+  zsync_curl -i "${ISO}" -o "${ISO}" "${ZSYNC_URL}" 2>&1
+  chmod $ORIG_MOD "${ISO}" # Set the same permissions as for the original file
   gpg_check
 elif [ "$TYPE" == "gh-releases-zsync" ] ; then
   cd $(dirname "${ISO}") 
@@ -168,10 +168,10 @@ elif [ "$TYPE" == "gh-releases-zsync" ] ; then
   echo "$REGEX"
   ZSYNC_URL=$(curl "$URL" | grep "$REGEX" | grep "browser_download_url" | cut -d '"' -f 4) # TODO: Get rid of curl command
   echo "$ZSYNC_URL"
+  ORIG_MOD=$(stat --format '%a' "${ISO}")
   # Get the file with zsync using $1 as an input file
-  zsync_curl -I -i "${ISO}" "${ZSYNC_URL}" 2>&1
-  NEWFILE=$(basename "${ZSYNC_URL}" | sed -e 's|.zsync||g' ) # FIXME: Use the file that zsync has written!!!
-  chmod --reference="${ISO}" "$(printf '%b' "${NEWFILE//%/\\x}")" # Set the same permissions as for the original file
+  zsync_curl -i "${ISO}" -o "${ISO}" "${ZSYNC_URL}" 2>&1
+  chmod $ORIG_MOD "${ISO}" # Set the same permissions as for the original file
   gpg_check
 elif [ "$TYPE" == "bintray-zsync" ] ; then
   cd $(dirname "${ISO}") 
@@ -199,10 +199,10 @@ elif [ "$TYPE" == "bintray-zsync" ] ; then
   fi
   ZSYNC_URL=$(echo "${DUMMY_URL}" | sed -e "s|_latestVersion|$VERSION|g" )
   echo "$ZSYNC_URL"
+  ORIG_MOD=$(stat --format '%a' "${ISO}")
   # Get the file with zsync using $1 as an input file
-  zsync_curl -I -i "${ISO}" "${ZSYNC_URL}" 2>&1
-  NEWFILE=$(basename "${ZSYNC_URL}" | sed -e 's|.zsync||g' ) # FIXME: Use the file that zsync has written!!!
-  chmod --reference="${ISO}" "$(printf '%b' "${NEWFILE//%/\\x}")" # Set the same permissions as for the original file
+  zsync_curl -i "${ISO}" -o "${ISO}" "${ZSYNC_URL}" 2>&1
+  chmod $ORIG_MOD "${ISO}" # Set the same permissions as for the original file
   gpg_check
 
 elif [ "$TYPE" == "" ] ; then


### PR DESCRIPTION
This is simply to ensure that zsync_curl uses the same AppImage filename when updating. Otherwise, if the user renames the AppImage, a new AppImage file would be created.