### PR TITLE
Removing objdump and using light_elf.h

### DIFF
--- a/resources/build-appimages.sh
+++ b/resources/build-appimages.sh
@@ -41,8 +41,7 @@ cp -v "$REPO_ROOT"/resources/*.desktop AppDir/usr/share/applications/
 cp -v "$REPO_ROOT"/resources/*.svg AppDir/usr/share/icons/hicolor/scalable/apps/
 cp -v "$REPO_ROOT"/resources/*.xpm AppDir/resources/
 
-# bundle objdump required for parsing update information
-cp /usr/bin/objdump AppDir/usr/bin/
+# no need for objdump to be bundled!
 
 # determine Git commit ID
 # linuxdeployqt uses this for naming the file
@@ -59,7 +58,7 @@ chmod +x linuxdeployqt-continuous-x86_64.AppImage
 
 # bundle applications
 ./linuxdeployqt-continuous-x86_64.AppImage AppDir/usr/share/applications/appimageupdatetool.desktop -verbose=1 -bundle-non-qt-libs \
-    -executable=AppDir/usr/bin/AppImageUpdate -executable=AppDir/usr/bin/AppImageSelfUpdate -executable=AppDir/usr/bin/objdump
+    -executable=AppDir/usr/bin/AppImageUpdate -executable=AppDir/usr/bin/AppImageSelfUpdate
 
 # get appimagetool
 wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage

--- a/src/light_elf.h
+++ b/src/light_elf.h
@@ -1,0 +1,119 @@
+/* 
+ * 
+ *  Linux kernel
+ *  Copyright (C) 2017 Linus Torvalds
+ *  Modified work Copyright (C) 2017 @teras (https://github.com/teras)
+ *  (Shortened version -- original work found here:
+ *   https://github.com/torvalds/linux/blob/master/include/uapi/linux/elf.h)
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ * 
+ */
+
+#ifndef _ELF_H
+#define _ELF_H 1
+
+#include <inttypes.h>
+
+__BEGIN_DECLS
+
+typedef uint16_t Elf32_Half;
+typedef uint16_t Elf64_Half;
+typedef uint32_t Elf32_Word;
+typedef uint32_t Elf64_Word;
+typedef uint64_t Elf64_Xword;
+typedef uint32_t Elf32_Addr;
+typedef uint64_t Elf64_Addr;
+typedef uint32_t Elf32_Off;
+typedef uint64_t Elf64_Off;
+
+#define EI_NIDENT 16
+
+typedef struct elf32_hdr {
+    unsigned char e_ident[EI_NIDENT];
+    Elf32_Half e_type;
+    Elf32_Half e_machine;
+    Elf32_Word e_version;
+    Elf32_Addr e_entry; /* Entry point */
+    Elf32_Off e_phoff;
+    Elf32_Off e_shoff;
+    Elf32_Word e_flags;
+    Elf32_Half e_ehsize;
+    Elf32_Half e_phentsize;
+    Elf32_Half e_phnum;
+    Elf32_Half e_shentsize;
+    Elf32_Half e_shnum;
+    Elf32_Half e_shstrndx;
+} Elf32_Ehdr;
+
+typedef struct elf64_hdr {
+    unsigned char e_ident[EI_NIDENT]; /* ELF "magic number" */
+    Elf64_Half e_type;
+    Elf64_Half e_machine;
+    Elf64_Word e_version;
+    Elf64_Addr e_entry; /* Entry point virtual address */
+    Elf64_Off e_phoff; /* Program header table file offset */
+    Elf64_Off e_shoff; /* Section header table file offset */
+    Elf64_Word e_flags;
+    Elf64_Half e_ehsize;
+    Elf64_Half e_phentsize;
+    Elf64_Half e_phnum;
+    Elf64_Half e_shentsize;
+    Elf64_Half e_shnum;
+    Elf64_Half e_shstrndx;
+} Elf64_Ehdr;
+
+typedef struct elf32_shdr {
+    Elf32_Word sh_name;
+    Elf32_Word sh_type;
+    Elf32_Word sh_flags;
+    Elf32_Addr sh_addr;
+    Elf32_Off sh_offset;
+    Elf32_Word sh_size;
+    Elf32_Word sh_link;
+    Elf32_Word sh_info;
+    Elf32_Word sh_addralign;
+    Elf32_Word sh_entsize;
+} Elf32_Shdr;
+
+typedef struct elf64_shdr {
+    Elf64_Word sh_name; /* Section name, index in string tbl */
+    Elf64_Word sh_type; /* Type of section */
+    Elf64_Xword sh_flags; /* Miscellaneous section attributes */
+    Elf64_Addr sh_addr; /* Section virtual addr at execution */
+    Elf64_Off sh_offset; /* Section file offset */
+    Elf64_Xword sh_size; /* Size of section in bytes */
+    Elf64_Word sh_link; /* Index of another section */
+    Elf64_Word sh_info; /* Additional section information */
+    Elf64_Xword sh_addralign; /* Section alignment */
+    Elf64_Xword sh_entsize; /* Entry size if section holds table */
+} Elf64_Shdr;
+
+/* Note header in a PT_NOTE section */
+typedef struct elf32_note {
+    Elf32_Word n_namesz; /* Name size */
+    Elf32_Word n_descsz; /* Content size */
+    Elf32_Word n_type; /* Content type */
+} Elf32_Nhdr;
+
+#define ELFCLASS32  1
+#define ELFDATA2LSB 1
+#define ELFDATA2MSB 2
+#define ELFCLASS64  2
+#define EI_CLASS    4
+#define EI_DATA     5
+
+__END_DECLS
+
+#endif /* elf.h */

--- a/src/util.h
+++ b/src/util.h
@@ -7,13 +7,25 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <stdio.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include "light_elf.h"
 
 namespace appimage {
     namespace update {
-        static void removeNewlineCharacters(std::string& str) {
-            str.erase(std::remove(str.begin(), str.end(), '\n'), str.end());
-        }
+        static std::vector<std::string> split(const std::string& s, char delim = ' ') {
+            std::vector<std::string> result;
 
+            std::stringstream ss(s);
+            std::string item;
+
+            while (std::getline(ss, item, delim)) {
+                result.push_back(item);
+            }
+
+            return result;
+        }
         static inline bool ltrim(std::string& s, char to_trim = ' ') {
             // TODO: find more efficient way to check whether elements have been removed
             size_t initialLength = s.length();
@@ -22,7 +34,7 @@ namespace appimage {
             }));
             return s.length() < initialLength;
         }
-
+        
         static inline bool rtrim(std::string& s, char to_trim = ' ') {
             // TODO: find more efficient way to check whether elements have been removed
             auto initialLength = s.length();
@@ -37,51 +49,7 @@ namespace appimage {
             auto ltrim_result = ltrim(s, to_trim);
             return rtrim(s, to_trim) && ltrim_result;
         }
-
-        static bool callProgramAndGrepForLine(const std::string& command, const std::string& pattern,
-                                              std::string& output) {
-            FILE *stream = popen(command.c_str(), "r");
-
-            if (stream == nullptr)
-                return false;
-
-            char *line;
-            size_t lineSize = 0;
-            while(getline(&line, &lineSize, stream)) {
-                // check whether line matches pattern
-                std::string lineString = line;
-                if (lineString.find(pattern) != std::string::npos) {
-                    if (pclose(stream) != 0) {
-                        free(line);
-                        return false;
-                    }
-                    output = line;
-                    removeNewlineCharacters(output);
-                    return true;
-                }
-            }
-
-            if (pclose(stream) != 0) {
-                free(line);
-                return false;
-            }
-
-            return false;
-        }
-
-        static std::vector<std::string> split(const std::string& s, char delim = ' ') {
-            std::vector<std::string> result;
-
-            std::stringstream ss(s);
-            std::string item;
-
-            while (std::getline(ss, item, delim)) {
-                result.push_back(item);
-            }
-
-            return result;
-        }
-
+        
         static inline std::string toLower(std::string s) {
             std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
             return s;


### PR DESCRIPTION
This **PR** replaces the system specific code for retriving **type 2 AppImage** update information using **objdump** with much better solution by using **light_elf.h**. 
This also avoids **bundling objdump** in the AppImage. 