### PR TITLE
Qt UI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ compiler: gcc
 sudo: require
 dist: trusty
 
+before_install:
+  - sudo add-apt-repository ppa:beineri/opt-qt593-trusty -y
+  - sudo apt-get update -qq
+
+install:
+  - sudo apt-get -y install qt59base
+  - source /opt/qt*/bin/qt*-env.sh
+
 before_script:
   - sudo bash -ex resources/bootstrap-container.sh
 

--- a/include/appimage/update/qt-ui.h
+++ b/include/appimage/update/qt-ui.h
@@ -1,0 +1,47 @@
+#include <QDialog>
+
+namespace appimage {
+    namespace update {
+        namespace qt {
+            class QtUpdater : public QDialog {
+                Q_OBJECT
+
+            private:
+                class Private;
+                Private* d;
+
+            public:
+                explicit QtUpdater(QString& pathToAppImage);
+                ~QtUpdater() override;
+
+            Q_SIGNALS:
+                void canceled();
+
+            private Q_SLOTS:
+                void updateProgress();
+                void runUpdatedAppImage();
+                void showCancelDialog();
+                void cancelUpdate();
+
+            private:
+                void init();
+
+            protected:
+                void closeEvent(QCloseEvent* event) override;
+                void showEvent(QShowEvent* event) override;
+                void keyPressEvent(QKeyEvent* event) override;
+
+            public:
+                // check for updates
+                // returns 0 if there's no update, 1 if there's an update available, any other value indicates an error
+                // if writeToStderr is set, writes status messages to stderr, which can be used for debugging etc.
+                int checkForUpdates(bool writeToStderr = false) const;
+
+                // create new QtUpdater instance from environment variable (i.e., when being called from within an
+                // AppImage, this method configures the instance automatically)
+                // returns nullptr if application isn't run from within an AppImage
+                static QtUpdater* fromEnv();
+            };
+        }
+    }
+}

--- a/resources/AppImageUpdate-Qt.desktop
+++ b/resources/AppImageUpdate-Qt.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=AppImageUpdate-Qt
+Type=Application
+Icon=AppImage
+Exec=AppImageUpdate-Qt

--- a/resources/AppImageUpdate-Qt.ignore
+++ b/resources/AppImageUpdate-Qt.ignore
@@ -1,3 +1,3 @@
 usr/include
 usr/bin/appimageupdatetool
-usr/bin/AppImageUpdate-Qt
+usr/bin/AppImageUpdate

--- a/resources/appimageupdatetool.ignore
+++ b/resources/appimageupdatetool.ignore
@@ -1,3 +1,4 @@
 usr/include
 usr/bin/AppImageUpdate
 usr/bin/AppImageSelfUpdate
+usr/bin/AppImageUpdate-Qt

--- a/resources/build-appimages.sh
+++ b/resources/build-appimages.sh
@@ -59,7 +59,8 @@ chmod +x linuxdeployqt-continuous-x86_64.AppImage
 
 # bundle applications
 ./linuxdeployqt-continuous-x86_64.AppImage AppDir/usr/share/applications/appimageupdatetool.desktop -verbose=1 -bundle-non-qt-libs \
-    -executable=AppDir/usr/bin/AppImageUpdate -executable=AppDir/usr/bin/AppImageSelfUpdate -executable=AppDir/usr/bin/objdump
+    -executable=AppDir/usr/bin/AppImageUpdate -executable=AppDir/usr/bin/AppImageSelfUpdate -executable=AppDir/usr/bin/objdump \
+    -executable=AppDir/usr/bin/AppImageUpdate-Qt
 
 # get appimagetool
 wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage

--- a/resources/build-appimages.sh
+++ b/resources/build-appimages.sh
@@ -83,8 +83,17 @@ popd
 ./appimagetool-x86_64.AppImage -v --exclude-file "$REPO_ROOT"/resources/AppImageUpdate.ignore AppDir \
     -u 'gh-releases-zsync|AppImage|AppImageUpdate|continuous|AppImageUpdate-*x86_64.AppImage.zsync'
 
+# change AppDir root to fit the GUI
+pushd AppDir
+rm AppRun && ln -s usr/bin/AppImageUpdate-Qt AppRun
+rm *.desktop && cp usr/share/applications/AppImageUpdate-Qt.desktop .
+popd
+
+# create AppImageUpdate AppImage
+./appimagetool-x86_64.AppImage -v --exclude-file "$REPO_ROOT"/resources/AppImageUpdate-Qt.ignore AppDir \
+    -u 'gh-releases-zsync|AppImage|AppImageUpdate|continuous|AppImageUpdate-Qt-*x86_64.AppImage.zsync'
+
 # move AppImages to old cwd
-mv appimageupdatetool*.AppImage* "$OLD_CWD"/
-mv AppImageUpdate*.AppImage* "$OLD_CWD"/
+mv {appimageupdatetool,AppImageUpdate}*.AppImage* "$OLD_CWD"/
 
 popd

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,36 +54,18 @@ target_link_libraries(AppImageUpdate libappimageupdate fltk fltk_images libdeskt
 target_compile_definitions(AppImageUpdate PRIVATE -DFLTK_UI)
 
 
-# Qt dependencies
-find_package(Qt5 REQUIRED COMPONENTS Core Widgets)
-
-# run moc automatically when needed
-set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_AUTOMOC ON)
-
-# library with the Qt UI classes
-add_library(libappimageupdate-qt qt-ui/qt-updater.cpp ${PROJECT_SOURCE_DIR}/include/appimage/update/qt-ui.h)
-target_link_libraries(libappimageupdate-qt libappimageupdate Qt5::Core Qt5::Widgets)
-target_include_directories(libappimageupdate-qt
-    PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-)
-target_compile_definitions(libappimageupdate-qt PRIVATE -DQT_UI)
-
-# Qt GUI application
-add_executable(AppImageUpdate-Qt qt-ui/main.cpp)
-add_sanitizers(AppImageUpdate-Qt)
-
-# link libraries
-target_link_libraries(AppImageUpdate-Qt libappimageupdate libappimageupdate-qt)
-target_compile_definitions(AppImageUpdate-Qt PRIVATE -DQT_UI)
-
 # install targets
 install(
-    TARGETS libappimageupdate appimageupdatetool AppImageUpdate AppImageUpdate-Qt
+    TARGETS libappimageupdate appimageupdatetool AppImageUpdate
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib/static
     INCLUDES DESTINATION include
 )
+
+
+# include Qt UI
+set(BUILD_QT_UI BOOL CACHE "bla" FALSE)
+if (BUILD_QT_UI)
+    add_subdirectory(qt-ui)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,10 +51,37 @@ add_sanitizers(AppImageUpdate)
 
 # link libraries
 target_link_libraries(AppImageUpdate libappimageupdate fltk fltk_images libdesktopenvironments ${X11_Xpm_LIB} args)
+target_compile_definitions(AppImageUpdate PRIVATE -DFLTK_UI)
+
+
+# Qt dependencies
+find_package(Qt5 REQUIRED COMPONENTS Core Widgets)
+
+# run moc automatically when needed
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
+
+# library with the Qt UI classes
+add_library(libappimageupdate-qt qt-ui/qt-updater.cpp ${PROJECT_SOURCE_DIR}/include/appimage/update/qt-ui.h)
+target_link_libraries(libappimageupdate-qt libappimageupdate Qt5::Core Qt5::Widgets)
+target_include_directories(libappimageupdate-qt
+    PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+target_compile_definitions(libappimageupdate-qt PRIVATE -DQT_UI)
+
+# Qt GUI application
+add_executable(AppImageUpdate-Qt qt-ui/main.cpp)
+add_sanitizers(AppImageUpdate-Qt)
+
+# link libraries
+target_link_libraries(AppImageUpdate-Qt libappimageupdate libappimageupdate-qt)
+target_compile_definitions(AppImageUpdate-Qt PRIVATE -DQT_UI)
 
 # install targets
 install(
-    TARGETS libappimageupdate appimageupdatetool AppImageUpdate
+    TARGETS libappimageupdate appimageupdatetool AppImageUpdate AppImageUpdate-Qt
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib/static

--- a/src/gui_main.cpp
+++ b/src/gui_main.cpp
@@ -146,7 +146,7 @@ void runUpdate(const std::string& pathToAppImage) {
         Fl::check();
     };
 
-    auto showFinishedDialog = [&runApp](string msg, string newAppImagePath) {
+    auto showFinishedDialog = [](string msg, string newAppImagePath) {
         switch (fl_choice(msg.c_str(), "Exit", "Run application", nullptr)) {
             case 0:
                 exit(0);

--- a/src/qt-ui/CMakeLists.txt
+++ b/src/qt-ui/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Qt dependencies
+find_package(Qt5 REQUIRED COMPONENTS Core Widgets)
+
+# run moc automatically when needed
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_AUTOMOC ON)
+
+# library with the Qt UI classes
+add_library(libappimageupdate-qt qt-updater.cpp ${PROJECT_SOURCE_DIR}/include/appimage/update/qt-ui.h)
+target_link_libraries(libappimageupdate-qt libappimageupdate Qt5::Core Qt5::Widgets)
+target_include_directories(libappimageupdate-qt
+    PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+target_compile_definitions(libappimageupdate-qt PRIVATE -DQT_UI)
+
+# Qt GUI application
+add_executable(AppImageUpdate-Qt main.cpp)
+add_sanitizers(AppImageUpdate-Qt)
+
+# link libraries
+target_link_libraries(AppImageUpdate-Qt libappimageupdate libappimageupdate-qt)
+target_compile_definitions(AppImageUpdate-Qt PRIVATE -DQT_UI)
+
+# install targets
+install(
+    TARGETS libappimageupdate-qt AppImageUpdate-Qt
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib/static
+    INCLUDES DESTINATION include
+)

--- a/src/qt-ui/CMakeLists.txt
+++ b/src/qt-ui/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 
 # library with the Qt UI classes
-add_library(libappimageupdate-qt qt-updater.cpp ${PROJECT_SOURCE_DIR}/include/appimage/update/qt-ui.h)
+add_library(libappimageupdate-qt qt-updater.cpp spoiler.cpp ${PROJECT_SOURCE_DIR}/include/appimage/update/qt-ui.h)
 target_link_libraries(libappimageupdate-qt libappimageupdate Qt5::Core Qt5::Widgets)
 target_include_directories(libappimageupdate-qt
     PUBLIC

--- a/src/qt-ui/main.cpp
+++ b/src/qt-ui/main.cpp
@@ -1,0 +1,109 @@
+// system headers
+#include <chrono>
+#include <iterator>
+#include <iostream>
+#include <thread>
+
+// library headers
+#include <QCommandLineParser>
+#include <QFileDialog>
+#include <QApplication>
+#include <zsutil.h>
+
+// local headers
+#include "appimage/update.h"
+#include "appimage/update/qt-ui.h"
+#include "util.h"
+
+using namespace std;
+using namespace appimage::update;
+
+int main(int argc, char** argv) {
+    cerr << "AppImageUpdate version " << APPIMAGEUPDATE_VERSION << " (commit " << APPIMAGEUPDATE_GIT_COMMIT << "), "
+         << "build " << BUILD_NUMBER << " built on " << BUILD_DATE << endl;
+
+    QApplication app(argc, argv);
+
+    QCommandLineParser parser;
+
+    parser.addHelpOption();
+//    parser.setSingleDashWordOptionMode(QCommandLineParser::ParseAsLongOptions);
+
+    parser.setApplicationDescription(QObject::tr(
+        "AppImageUpdate -- GUI for updating AppImages, Qt edition"
+    ));
+
+    QCommandLineOption showVersion({"v", "version"}, "Display version and exit.");
+    parser.addOption(showVersion);
+
+    QCommandLineOption checkForUpdate(
+        {"j", "check-for-update"},
+        "Check for update. Exits with code 1 if changes are available, 0 if there are not,"
+            "other non-zero code in case of errors."
+    );
+    parser.addOption(checkForUpdate);
+
+    QCommandLineOption selfUpdate("self-update", "Update the tool itself and exit.");
+    parser.addOption(selfUpdate);
+
+    parser.addPositionalArgument("path", "Path to AppImage that should be updated", "<AppImage>");
+
+    parser.process(app);
+
+    if (parser.isSet(showVersion)) {
+        // version has been printed already, so we can just exit here
+        return 0;
+    }
+
+    QString pathToAppImage;
+
+    appimage::update::qt::QtUpdater* updater;
+
+    // if a self-update is requested, check whether the path argument has been passed, and show an error
+    // otherwise check whether path has been passed on the CLI, otherwise show file chooser
+    if (parser.isSet(selfUpdate)) {
+        if (!parser.positionalArguments().empty()) {
+            cerr << "Error: --self-update does not take a path." << endl;
+            parser.showHelp(1);
+        } else {
+            updater = appimage::update::qt::QtUpdater::fromEnv();
+
+            if (updater == nullptr) {
+                cerr << "Error: self update requested but could not determine path to AppImage "
+                     << "($APPIMAGE environment variable missing)."
+                     << endl;
+                return 1;
+            }
+        }
+    } else {
+        if (!parser.positionalArguments().empty()) {
+            pathToAppImage = parser.positionalArguments().front();
+        } else {
+            pathToAppImage = QFileDialog::getOpenFileName(
+                Q_NULLPTR,
+                "Please choose an AppImage for updating",
+                QDir::currentPath(),
+                "AppImage (*.appimage *.AppImage);;All files (*)"
+            );
+            if (pathToAppImage.isNull()) {
+                cerr << "No file selected, exiting.";
+                return 1;
+            }
+        }
+
+        // make absolute
+        pathToAppImage = QFileInfo(pathToAppImage).absoluteFilePath();
+
+        updater = new appimage::update::qt::QtUpdater(pathToAppImage);
+    }
+
+    if (parser.isSet(checkForUpdate))
+        return updater->checkForUpdates(true);
+
+    updater->show();
+
+    auto rv = app.exec();
+
+    delete updater;
+    return rv;
+}

--- a/src/qt-ui/main.cpp
+++ b/src/qt-ui/main.cpp
@@ -19,7 +19,7 @@ using namespace std;
 using namespace appimage::update;
 
 int main(int argc, char** argv) {
-    cerr << "AppImageUpdate version " << APPIMAGEUPDATE_VERSION << " (commit " << APPIMAGEUPDATE_GIT_COMMIT << "), "
+    cerr << "AppImageUpdate-Qt version " << APPIMAGEUPDATE_VERSION << " (commit " << APPIMAGEUPDATE_GIT_COMMIT << "), "
          << "build " << BUILD_NUMBER << " built on " << BUILD_DATE << endl;
 
     QApplication app(argc, argv);

--- a/src/qt-ui/main.cpp
+++ b/src/qt-ui/main.cpp
@@ -13,7 +13,7 @@
 // local headers
 #include "appimage/update.h"
 #include "appimage/update/qt-ui.h"
-#include "util.h"
+#include "../util.h"
 
 using namespace std;
 using namespace appimage::update;

--- a/src/qt-ui/qt-updater.cpp
+++ b/src/qt-ui/qt-updater.cpp
@@ -49,6 +49,8 @@ namespace appimage {
 
                 bool finished;
 
+                const int minimumWidth;
+
             public:
                 explicit Private(QString& pathToAppImage) : buttonBox(nullptr),
                                                             progressBar(nullptr),
@@ -60,7 +62,8 @@ namespace appimage {
                                                             spoiler(nullptr),
                                                             spoilerLayout(nullptr),
                                                             spoilerLog(nullptr),
-                                                            finished(false)
+                                                            finished(false),
+                                                            minimumWidth(400)
                 {
                     if (!isFile(pathToAppImage.toStdString()))
                         throw std::runtime_error("No such file or directory: " + pathToAppImage.toStdString());
@@ -129,20 +132,23 @@ namespace appimage {
                 layout()->setSizeConstraint(QLayout::SetFixedSize);
 
                 d->label = new QLabel(QString("Updating " + d->appImageFileName + "..."));
+                d->label->setMinimumWidth(d->minimumWidth);
                 layout()->addWidget(d->label);
 
                 d->progressBar = new QProgressBar();
-                d->progressBar->resize(200, 24);
+                d->progressBar->setMinimumWidth(d->minimumWidth);
                 d->progressBar->setMinimum(0);
                 d->progressBar->setMaximum(100);
                 layout()->addWidget(d->progressBar);
 
                 d->progressLabel = new QLabel(this);
+                d->progressLabel->setMinimumWidth(d->minimumWidth);
                 d->progressLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
                 d->progressLabel->setText("Starting update...");
                 layout()->addWidget(d->progressLabel);
 
                 d->spoiler = new Spoiler("Details");
+                d->spoiler->resize(QSize(d->minimumWidth, 200));
                 d->spoilerLayout = new QVBoxLayout();
                 d->spoilerLog = new QPlainTextEdit();
                 d->spoilerLog->setReadOnly(true);
@@ -157,6 +163,8 @@ namespace appimage {
                 d->progressTimer = new QTimer(this);
                 connect(d->progressTimer, SIGNAL(timeout()), this, SLOT(updateProgress()));
                 d->progressTimer->start(100);
+
+                adjustSize();
             }
 
             void QtUpdater::updateProgress() {

--- a/src/qt-ui/qt-updater.cpp
+++ b/src/qt-ui/qt-updater.cpp
@@ -1,0 +1,274 @@
+// global headers
+#include <iostream>
+
+// library headers
+#include <QCloseEvent>
+#include <QDialogButtonBox>
+#include <QFileInfo>
+#include <QGroupBox>
+#include <QLabel>
+#include <QLayout>
+#include <QMessageBox>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QProgressDialog>
+#include <QTimer>
+
+// local headers
+#include "appimage/update/qt-ui.h"
+#include "appimage/update.h"
+#include "util.h"
+
+namespace appimage {
+    namespace update {
+        namespace qt {
+            class QtUpdater::Private {
+            public:
+                const QString pathToAppImage;
+                appimage::update::Updater* updater;
+
+                QLabel* label;
+                QDialogButtonBox* buttonBox;
+
+                QProgressBar* progressBar;
+
+                QLayout* mainLayout;
+
+                QString appName;
+                QString appImageFileName;
+
+                QTimer* progressTimer;
+
+            public:
+                explicit Private(QString& pathToAppImage) : buttonBox(nullptr),
+                                                            progressBar(nullptr),
+                                                            mainLayout(nullptr),
+                                                            label(nullptr),
+                                                            progressTimer(nullptr),
+                                                            pathToAppImage(pathToAppImage)
+                {
+                    if (!isFile(pathToAppImage.toStdString()))
+                        throw std::runtime_error("No such file or directory: " + pathToAppImage.toStdString());
+
+                    updater = new Updater(pathToAppImage.toStdString());
+
+                    auto fileInfo = QFileInfo(pathToAppImage);
+
+                    {
+                        auto appName = fileInfo.baseName();
+
+                        QStringList archs;
+                        archs << "x86_64" << "i386" << "i586" << "i686" << "x64" << "x86";
+                        for (const auto& arch : archs)
+                            appName.replace(arch, "");
+
+                        auto stdAppName = appName.toStdString();
+                        trim(stdAppName, '-');
+                        appName = QString::fromStdString(stdAppName);
+
+                        this->appName = appName;
+                    }
+
+                    appImageFileName = fileInfo.baseName() + "." + fileInfo.suffix();
+                }
+
+                ~Private() {
+                    delete updater;
+                    delete label;
+                    delete buttonBox;
+                    delete progressBar;
+                    delete mainLayout;
+                    delete progressTimer;
+                }
+
+            public:
+                void startUpdate() {
+                    updater->start();
+                }
+            };
+
+            QtUpdater::QtUpdater(QString& pathToAppImage) {
+                d = new Private(pathToAppImage);
+
+                init();
+            }
+
+            QtUpdater::~QtUpdater() {
+                delete d;
+            }
+
+            void QtUpdater::init() {
+                // replace default cancel button handling
+                setWindowTitle(QString("Updating " + d->appName));
+                // make it a modal dialog
+                // doesn't have an effect in the standalone AppImageUpdate-Qt app, but should improve UX when being
+                // integrated in other apps
+                setModal(true);
+
+                resize(QSize(360, 150));
+
+                d->mainLayout = new QVBoxLayout();
+                setLayout(d->mainLayout);
+
+                d->label = new QLabel(QString("Updating " + d->appImageFileName + "..."));
+                layout()->addWidget(d->label);
+
+                d->progressBar = new QProgressBar();
+                d->progressBar->resize(200, 24);
+                d->progressBar->setMinimum(0);
+                d->progressBar->setMaximum(100);
+                layout()->addWidget(d->progressBar);
+
+                d->buttonBox = new QDialogButtonBox(QDialogButtonBox::Cancel);
+                connect(d->buttonBox, SIGNAL(rejected()), this, SLOT(showCancelDialog()));
+                layout()->addWidget(d->buttonBox);
+
+                d->progressTimer = new QTimer(this);
+                connect(d->progressTimer, SIGNAL(timeout()), this, SLOT(updateProgress()));
+                d->progressTimer->start(100);
+            }
+
+            void QtUpdater::updateProgress() {
+                    double progress;
+
+                    if (!d->updater->progress(progress))
+                        return;
+
+                    d->progressBar->setValue(((int) progress) * 100);
+
+                    std::string nextMessage;
+                    while (d->updater->nextStatusMessage(nextMessage))
+                        std::cerr << nextMessage << std::endl;
+
+                if (d->updater->isDone()) {
+                    d->progressTimer->stop();
+
+                    auto palette = d->progressBar->palette();
+
+                    if (d->updater->hasError()) {
+                        d->label->setText("Update failed!");
+                        palette.setColor(QPalette::Highlight, Qt::red);
+                    } else {
+                        d->label->setText("Update successful!");
+                        palette.setColor(QPalette::Highlight, Qt::green);
+                    }
+
+                    // TODO: doesn't work with the Gtk+ platform theme
+                    d->progressBar->setPalette(palette);
+
+                    // replace button box
+                    disconnect(d->buttonBox, SIGNAL(rejected()));
+                    delete d->buttonBox;
+
+                    d->buttonBox = new QDialogButtonBox();
+
+                    d->buttonBox->addButton("Run updated AppImage", QDialogButtonBox::AcceptRole);
+                    d->buttonBox->addButton("Close", QDialogButtonBox::RejectRole);
+
+                    connect(d->buttonBox, SIGNAL(accepted()), this, SLOT(runUpdatedAppImage()));
+                    connect(d->buttonBox, &QDialogButtonBox::rejected, this, [this]() {
+                        this->done(0);
+                    });
+
+                    layout()->addWidget(d->buttonBox);
+                }
+            }
+
+            int QtUpdater::checkForUpdates(bool writeToStderr) const {
+                appimage::update::Updater updater(d->pathToAppImage.toStdString());
+
+                bool changesAvailable = false;
+
+                auto result = updater.checkForChanges(changesAvailable);
+
+                // print all messages that might be available
+                if (writeToStderr) {
+                    std::string nextMessage;
+                    while (updater.nextStatusMessage(nextMessage))
+                        std::cerr << nextMessage << std::endl;
+                }
+
+                if (!result)
+                    return 2;
+
+                if (changesAvailable) {
+                    std::cerr << "Update available" << std::endl;
+                    return 1;
+                } else {
+                    std::cerr << "AppImage already up to date" << std::endl;
+                    return 0;
+                }
+            }
+
+            void QtUpdater::closeEvent(QCloseEvent* event) {
+                // ignore event...
+                event->ignore();
+
+                // ... and show cancel dialog
+                showCancelDialog();
+            }
+
+            void QtUpdater::showEvent(QShowEvent* event) {
+                QDialog::showEvent(event);
+
+                d->startUpdate();
+            }
+
+            void QtUpdater::runUpdatedAppImage() {
+                std::string pathToNewAppImage;
+
+                if (!d->updater->pathToNewFile(pathToNewAppImage))
+                    throw std::runtime_error("Could not detect path to new AppImage");
+
+                runApp(pathToNewAppImage);
+                done(0);
+            }
+
+            void QtUpdater::showCancelDialog() {
+                // prepare message box
+                auto button = QMessageBox::critical(
+                    this,
+                    "Cancel update", "Do you want to cancel the update process?",
+                    QMessageBox::No | QMessageBox::Yes,
+                    QMessageBox::Yes
+                );
+
+                switch (button) {
+                    case QMessageBox::Yes:
+                        cancelUpdate();
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            void QtUpdater::cancelUpdate() {
+                std::cerr << "canceled" << std::endl;
+
+                if (!d->updater->isDone())
+                    d->updater->stop();
+
+                done(1);
+            }
+
+            QtUpdater* QtUpdater::fromEnv() {
+                auto* APPIMAGE = getenv("APPIMAGE");
+
+                if (APPIMAGE == nullptr || !isFile(APPIMAGE))
+                    return nullptr;
+
+                auto pathToAppImage = QString(APPIMAGE);
+                return new QtUpdater(pathToAppImage);
+            }
+
+            void QtUpdater::keyPressEvent(QKeyEvent* event) {
+                if (event->key() == Qt::Key_Escape) {
+                    event->ignore();
+                    showCancelDialog();
+                } else {
+                    QDialog::keyPressEvent(event);
+                }
+            }
+        }
+    }
+}

--- a/src/qt-ui/qt-updater.cpp
+++ b/src/qt-ui/qt-updater.cpp
@@ -17,7 +17,7 @@
 // local headers
 #include "appimage/update/qt-ui.h"
 #include "appimage/update.h"
-#include "util.h"
+#include "../util.h"
 
 namespace appimage {
     namespace update {

--- a/src/qt-ui/qt-updater.cpp
+++ b/src/qt-ui/qt-updater.cpp
@@ -162,10 +162,12 @@ namespace appimage {
 
                     d->buttonBox = new QDialogButtonBox();
 
-                    d->buttonBox->addButton("Run updated AppImage", QDialogButtonBox::AcceptRole);
-                    d->buttonBox->addButton("Close", QDialogButtonBox::RejectRole);
+                    if (!d->updater->hasError()) {
+                        d->buttonBox->addButton("Run updated AppImage", QDialogButtonBox::AcceptRole);
+                        connect(d->buttonBox, SIGNAL(accepted()), this, SLOT(runUpdatedAppImage()));
+                    }
 
-                    connect(d->buttonBox, SIGNAL(accepted()), this, SLOT(runUpdatedAppImage()));
+                    d->buttonBox->addButton("Close", QDialogButtonBox::RejectRole);
                     connect(d->buttonBox, &QDialogButtonBox::rejected, this, [this]() {
                         this->done(0);
                     });

--- a/src/qt-ui/spoiler.cpp
+++ b/src/qt-ui/spoiler.cpp
@@ -1,5 +1,6 @@
 // based on https://stackoverflow.com/a/37927256
 
+#include <QApplication>
 #include <QPropertyAnimation>
 
 #include "spoiler.h"
@@ -34,6 +35,7 @@ Spoiler::Spoiler(const QString& title, const int animationDuration, QWidget* par
     mainLayout.setVerticalSpacing(0);
     mainLayout.setContentsMargins(0, 0, 0, 0);
     int row = 0;
+
     mainLayout.addWidget(&toggleButton, row, 0, 1, 1, Qt::AlignLeft);
     mainLayout.addWidget(&headerLine, row++, 2, 1, 1);
     mainLayout.addWidget(&contentArea, row, 0, 1, 3);
@@ -51,12 +53,16 @@ void Spoiler::setContentLayout(QLayout& contentLayout) {
     contentArea.setLayout(&contentLayout);
     const auto collapsedHeight = sizeHint().height() - contentArea.maximumHeight();
     auto contentHeight = contentLayout.sizeHint().height();
+
     for (int i = 0; i < toggleAnimation.animationCount() - 1; ++i) {
         auto* spoilerAnimation = dynamic_cast<QPropertyAnimation*>(toggleAnimation.animationAt(i));
         spoilerAnimation->setDuration(animationDuration);
         spoilerAnimation->setStartValue(collapsedHeight);
         spoilerAnimation->setEndValue(collapsedHeight + contentHeight);
     }
+
+    auto* w = QApplication::activeWindow();
+
     auto* contentAnimation = dynamic_cast<QPropertyAnimation*>(toggleAnimation.animationAt(toggleAnimation.animationCount() - 1));
     contentAnimation->setDuration(animationDuration);
     contentAnimation->setStartValue(0);

--- a/src/qt-ui/spoiler.cpp
+++ b/src/qt-ui/spoiler.cpp
@@ -1,0 +1,64 @@
+// based on https://stackoverflow.com/a/37927256
+
+#include <QPropertyAnimation>
+
+#include "spoiler.h"
+
+Spoiler::Spoiler(const QString& title, const int animationDuration, QWidget* parent) : QWidget(parent),
+                                                                                       animationDuration(animationDuration)
+{
+    toggleButton.setStyleSheet("QToolButton { border: none; }");
+    toggleButton.setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
+    toggleButton.setArrowType(Qt::ArrowType::RightArrow);
+    toggleButton.setText(title);
+    toggleButton.setCheckable(true);
+    toggleButton.setChecked(false);
+
+    headerLine.setFrameShape(QFrame::HLine);
+    headerLine.setFrameShadow(QFrame::Sunken);
+    headerLine.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Maximum);
+
+    contentArea.setStyleSheet("QScrollArea { background-color: white; border: none; }");
+    contentArea.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+
+    // start out collapsed
+    contentArea.setMaximumHeight(0);
+    contentArea.setMinimumHeight(0);
+
+    // let the entire widget grow and shrink with its content
+    toggleAnimation.addAnimation(new QPropertyAnimation(this, "minimumHeight"));
+    toggleAnimation.addAnimation(new QPropertyAnimation(this, "maximumHeight"));
+    toggleAnimation.addAnimation(new QPropertyAnimation(&contentArea, "maximumHeight"));
+
+    // don't waste space
+    mainLayout.setVerticalSpacing(0);
+    mainLayout.setContentsMargins(0, 0, 0, 0);
+    int row = 0;
+    mainLayout.addWidget(&toggleButton, row, 0, 1, 1, Qt::AlignLeft);
+    mainLayout.addWidget(&headerLine, row++, 2, 1, 1);
+    mainLayout.addWidget(&contentArea, row, 0, 1, 3);
+    setLayout(&mainLayout);
+
+    QObject::connect(&toggleButton, &QToolButton::clicked, [this](const bool checked) {
+        toggleButton.setArrowType(checked ? Qt::ArrowType::DownArrow : Qt::ArrowType::RightArrow);
+        toggleAnimation.setDirection(checked ? QAbstractAnimation::Forward : QAbstractAnimation::Backward);
+        toggleAnimation.start();
+    });
+}
+
+void Spoiler::setContentLayout(QLayout& contentLayout) {
+    delete contentArea.layout();
+    contentArea.setLayout(&contentLayout);
+    const auto collapsedHeight = sizeHint().height() - contentArea.maximumHeight();
+    auto contentHeight = contentLayout.sizeHint().height();
+    for (int i = 0; i < toggleAnimation.animationCount() - 1; ++i) {
+        auto* spoilerAnimation = dynamic_cast<QPropertyAnimation*>(toggleAnimation.animationAt(i));
+        spoilerAnimation->setDuration(animationDuration);
+        spoilerAnimation->setStartValue(collapsedHeight);
+        spoilerAnimation->setEndValue(collapsedHeight + contentHeight);
+    }
+    auto* contentAnimation = dynamic_cast<QPropertyAnimation*>(toggleAnimation.animationAt(toggleAnimation.animationCount() - 1));
+    contentAnimation->setDuration(animationDuration);
+    contentAnimation->setStartValue(0);
+    contentAnimation->setEndValue(contentHeight);
+}

--- a/src/qt-ui/spoiler.h
+++ b/src/qt-ui/spoiler.h
@@ -1,0 +1,24 @@
+// based on https://stackoverflow.com/a/37927256
+
+#pragma once
+
+#include <QFrame>
+#include <QGridLayout>
+#include <QParallelAnimationGroup>
+#include <QScrollArea>
+#include <QToolButton>
+#include <QWidget>
+
+class Spoiler : public QWidget {
+    Q_OBJECT
+    private:
+        QGridLayout mainLayout;
+        QToolButton toggleButton;
+        QFrame headerLine;
+        QParallelAnimationGroup toggleAnimation;
+        QScrollArea contentArea;
+        int animationDuration{300};
+    public:
+        explicit Spoiler(const QString & title = "", int animationDuration = 300, QWidget *parent = 0);
+        void setContentLayout(QLayout & contentLayout);
+};

--- a/src/util.h
+++ b/src/util.h
@@ -7,6 +7,17 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <unistd.h>
+
+#ifdef FLTK_UI
+    #include <FL/Fl.H>
+#endif
+#ifdef QT_UI
+    #include <QMessageBox>
+#endif
+
+// library includes
+#include <zsutil.h>
 
 namespace appimage {
     namespace update {
@@ -104,4 +115,54 @@ namespace appimage {
             return (bool) ifs && ifs.good();
         }
     }
+
+    static void runApp(const std::string& path) {
+        // make executable
+        mode_t newPerms;
+        auto errCode = zsync2::getPerms(path, newPerms);
+
+        if (errCode != 0) {
+            std::ostringstream ss;
+            ss << "Error calling stat(): " << strerror(errCode);
+#ifdef FLTK_UI
+            fl_message("%s", ss.str().c_str());
+#endif
+#ifdef QT_UI
+            QMessageBox::critical(nullptr, "Error", QString::fromStdString(ss.str()), QMessageBox::Close);
+#endif
+            exit(1);
+        }
+
+        chmod(path.c_str(), newPerms | S_IXUSR);
+
+        // full path to AppImage, required for execl
+        char* realPathToAppImage;
+        if ((realPathToAppImage = realpath(path.c_str(), nullptr)) == nullptr) {
+            auto error = errno;
+            std::ostringstream ss;
+            ss << "Error resolving full path of AppImage: code " << error << ": " << strerror(error) << std::endl;
+#ifdef FLTK_UI
+            fl_message("%s", ss.str().c_str());
+#endif
+#ifdef QT_UI
+            QMessageBox::critical(nullptr, "Error", QString::fromStdString(ss.str()), QMessageBox::Close);
+#endif
+            exit(1);
+        }
+
+        if (fork() == 0) {
+            putenv(strdup("STARTED_BY_APPIMAGEUPDATE=1"));
+
+            std::cerr << "Running " << realPathToAppImage << std::endl;
+
+            // make sure to deactivate updater contained in the AppImage when running from AppImageUpdate
+            execl(realPathToAppImage, realPathToAppImage, nullptr);
+
+            // execle should never return, so if this code is reached, there must be an error
+            auto error = errno;
+            std::cerr << "Error executing AppImage " << realPathToAppImage << ": code " << error << ": "
+                      << strerror(error) << std::endl;
+            exit(1);
+        }
+    };
 }

--- a/src/util.h
+++ b/src/util.h
@@ -114,55 +114,55 @@ namespace appimage {
             std::ifstream ifs(path);
             return (bool) ifs && ifs.good();
         }
-    }
 
-    static void runApp(const std::string& path) {
-        // make executable
-        mode_t newPerms;
-        auto errCode = zsync2::getPerms(path, newPerms);
+        static void runApp(const std::string& path) {
+            // make executable
+            mode_t newPerms;
+            auto errCode = zsync2::getPerms(path, newPerms);
 
-        if (errCode != 0) {
-            std::ostringstream ss;
-            ss << "Error calling stat(): " << strerror(errCode);
+            if (errCode != 0) {
+                std::ostringstream ss;
+                ss << "Error calling stat(): " << strerror(errCode);
 #ifdef FLTK_UI
-            fl_message("%s", ss.str().c_str());
+                fl_message("%s", ss.str().c_str());
 #endif
 #ifdef QT_UI
-            QMessageBox::critical(nullptr, "Error", QString::fromStdString(ss.str()), QMessageBox::Close);
+                QMessageBox::critical(nullptr, "Error", QString::fromStdString(ss.str()), QMessageBox::Close);
 #endif
-            exit(1);
-        }
+                exit(1);
+            }
 
-        chmod(path.c_str(), newPerms | S_IXUSR);
+            chmod(path.c_str(), newPerms | S_IXUSR);
 
-        // full path to AppImage, required for execl
-        char* realPathToAppImage;
-        if ((realPathToAppImage = realpath(path.c_str(), nullptr)) == nullptr) {
-            auto error = errno;
-            std::ostringstream ss;
-            ss << "Error resolving full path of AppImage: code " << error << ": " << strerror(error) << std::endl;
+            // full path to AppImage, required for execl
+            char* realPathToAppImage;
+            if ((realPathToAppImage = realpath(path.c_str(), nullptr)) == nullptr) {
+                auto error = errno;
+                std::ostringstream ss;
+                ss << "Error resolving full path of AppImage: code " << error << ": " << strerror(error) << std::endl;
 #ifdef FLTK_UI
-            fl_message("%s", ss.str().c_str());
+                fl_message("%s", ss.str().c_str());
 #endif
 #ifdef QT_UI
-            QMessageBox::critical(nullptr, "Error", QString::fromStdString(ss.str()), QMessageBox::Close);
+                QMessageBox::critical(nullptr, "Error", QString::fromStdString(ss.str()), QMessageBox::Close);
 #endif
-            exit(1);
-        }
+                exit(1);
+            }
 
-        if (fork() == 0) {
-            putenv(strdup("STARTED_BY_APPIMAGEUPDATE=1"));
+            if (fork() == 0) {
+                putenv(strdup("STARTED_BY_APPIMAGEUPDATE=1"));
 
-            std::cerr << "Running " << realPathToAppImage << std::endl;
+                std::cerr << "Running " << realPathToAppImage << std::endl;
 
-            // make sure to deactivate updater contained in the AppImage when running from AppImageUpdate
-            execl(realPathToAppImage, realPathToAppImage, nullptr);
+                // make sure to deactivate updater contained in the AppImage when running from AppImageUpdate
+                execl(realPathToAppImage, realPathToAppImage, nullptr);
 
-            // execle should never return, so if this code is reached, there must be an error
-            auto error = errno;
-            std::cerr << "Error executing AppImage " << realPathToAppImage << ": code " << error << ": "
-                      << strerror(error) << std::endl;
-            exit(1);
+                // execle should never return, so if this code is reached, there must be an error
+                auto error = errno;
+                std::cerr << "Error executing AppImage " << realPathToAppImage << ": code " << error << ": "
+                          << strerror(error) << std::endl;
+                exit(1);
+            }
         }
     };
 }


### PR DESCRIPTION
This is a WIP Qt UI for AppImageUpdate.

The UI is developed for two scenarios: standalone and library use.

The standalone application merely serves as a feature demo, simplifying development. It might replace the FLTK dialog eventually. Otherwise, we'll have to decide whether to upload the Qt AppImage to GitHub releases at all. Having two standalone applications might confuse users. (Same problem will arise once we implement a Gtk+ UI, by the way, so let's have an actual discussion before making any hasty decisions.

The latter use case relates to our idea of having a kind of "standard" UI which Qt applications can integrate and use. By `show()`ing the dialog, the update process is started, and after finishing the update, the user can choose whether to run the new application or close the dialog and proceed with the old version.

It also features a Qt wrapper for the update checks, which can be used by the applications to check for changes before showing the update dialog.

TODO:

- [ ] allow apps to customize the UI
  - [ ] change "Run" button functionality to allow running custom clean-up code before running the new AppImage
- [ ] add function to query path to new AppImage
- [ ] sort out Gtk+ platform theme issue (see in-code TODO notes)
- [ ] ...

Feel free to post suggestions.

CC @dirkhh: this Qt UI might be interesting for Subsurface. With minimal effort, you could implement self updates for the Linux platform. I'd love to see Subsurface implement this UI as the first project. I can assist with that, if you like.