### PR TITLE
Replace objdump

### DIFF
--- a/cmake/DownloadProject.CMakeLists.cmake.in
+++ b/cmake/DownloadProject.CMakeLists.cmake.in
@@ -1,0 +1,17 @@
+# Distributed under the OSI-approved MIT License.  See accompanying
+# file LICENSE or https://github.com/Crascit/DownloadProject for details.
+
+cmake_minimum_required(VERSION 2.8.2)
+
+project(${DL_ARGS_PROJ}-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(${DL_ARGS_PROJ}-download
+                    ${DL_ARGS_UNPARSED_ARGUMENTS}
+                    SOURCE_DIR          "${DL_ARGS_SOURCE_DIR}"
+                    BINARY_DIR          "${DL_ARGS_BINARY_DIR}"
+                    CONFIGURE_COMMAND   ""
+                    BUILD_COMMAND       ""
+                    INSTALL_COMMAND     ""
+                    TEST_COMMAND        ""
+)

--- a/cmake/DownloadProject.LICENSE.txt
+++ b/cmake/DownloadProject.LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Crascit
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cmake/DownloadProject.cmake
+++ b/cmake/DownloadProject.cmake
@@ -1,0 +1,182 @@
+# Distributed under the OSI-approved MIT License.  See accompanying
+# file LICENSE or https://github.com/Crascit/DownloadProject for details.
+#
+# MODULE:   DownloadProject
+#
+# PROVIDES:
+#   download_project( PROJ projectName
+#                    [PREFIX prefixDir]
+#                    [DOWNLOAD_DIR downloadDir]
+#                    [SOURCE_DIR srcDir]
+#                    [BINARY_DIR binDir]
+#                    [QUIET]
+#                    ...
+#   )
+#
+#       Provides the ability to download and unpack a tarball, zip file, git repository,
+#       etc. at configure time (i.e. when the cmake command is run). How the downloaded
+#       and unpacked contents are used is up to the caller, but the motivating case is
+#       to download source code which can then be included directly in the build with
+#       add_subdirectory() after the call to download_project(). Source and build
+#       directories are set up with this in mind.
+#
+#       The PROJ argument is required. The projectName value will be used to construct
+#       the following variables upon exit (obviously replace projectName with its actual
+#       value):
+#
+#           projectName_SOURCE_DIR
+#           projectName_BINARY_DIR
+#
+#       The SOURCE_DIR and BINARY_DIR arguments are optional and would not typically
+#       need to be provided. They can be specified if you want the downloaded source
+#       and build directories to be located in a specific place. The contents of
+#       projectName_SOURCE_DIR and projectName_BINARY_DIR will be populated with the
+#       locations used whether you provide SOURCE_DIR/BINARY_DIR or not.
+#
+#       The DOWNLOAD_DIR argument does not normally need to be set. It controls the
+#       location of the temporary CMake build used to perform the download.
+#
+#       The PREFIX argument can be provided to change the base location of the default
+#       values of DOWNLOAD_DIR, SOURCE_DIR and BINARY_DIR. If all of those three arguments
+#       are provided, then PREFIX will have no effect. The default value for PREFIX is
+#       CMAKE_BINARY_DIR.
+#
+#       The QUIET option can be given if you do not want to show the output associated
+#       with downloading the specified project.
+#
+#       In addition to the above, any other options are passed through unmodified to
+#       ExternalProject_Add() to perform the actual download, patch and update steps.
+#       The following ExternalProject_Add() options are explicitly prohibited (they
+#       are reserved for use by the download_project() command):
+#
+#           CONFIGURE_COMMAND
+#           BUILD_COMMAND
+#           INSTALL_COMMAND
+#           TEST_COMMAND
+#
+#       Only those ExternalProject_Add() arguments which relate to downloading, patching
+#       and updating of the project sources are intended to be used. Also note that at
+#       least one set of download-related arguments are required.
+#
+#       If using CMake 3.2 or later, the UPDATE_DISCONNECTED option can be used to
+#       prevent a check at the remote end for changes every time CMake is run
+#       after the first successful download. See the documentation of the ExternalProject
+#       module for more information. It is likely you will want to use this option if it
+#       is available to you. Note, however, that the ExternalProject implementation contains
+#       bugs which result in incorrect handling of the UPDATE_DISCONNECTED option when
+#       using the URL download method or when specifying a SOURCE_DIR with no download
+#       method. Fixes for these have been created, the last of which is scheduled for
+#       inclusion in CMake 3.8.0. Details can be found here:
+#
+#           https://gitlab.kitware.com/cmake/cmake/commit/bdca68388bd57f8302d3c1d83d691034b7ffa70c
+#           https://gitlab.kitware.com/cmake/cmake/issues/16428
+#
+#       If you experience build errors related to the update step, consider avoiding
+#       the use of UPDATE_DISCONNECTED.
+#
+# EXAMPLE USAGE:
+#
+#   include(DownloadProject)
+#   download_project(PROJ                googletest
+#                    GIT_REPOSITORY      https://github.com/google/googletest.git
+#                    GIT_TAG             master
+#                    UPDATE_DISCONNECTED 1
+#                    QUIET
+#   )
+#
+#   add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR})
+#
+#========================================================================================
+
+
+set(_DownloadProjectDir "${CMAKE_CURRENT_LIST_DIR}")
+
+include(CMakeParseArguments)
+
+function(download_project)
+
+    set(options QUIET)
+    set(oneValueArgs
+        PROJ
+        PREFIX
+        DOWNLOAD_DIR
+        SOURCE_DIR
+        BINARY_DIR
+        # Prevent the following from being passed through
+        CONFIGURE_COMMAND
+        BUILD_COMMAND
+        INSTALL_COMMAND
+        TEST_COMMAND
+    )
+    set(multiValueArgs "")
+
+    cmake_parse_arguments(DL_ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    # Hide output if requested
+    if(DL_ARGS_QUIET)
+        set(OUTPUT_QUIET "OUTPUT_QUIET")
+    else()
+        unset(OUTPUT_QUIET)
+        message(STATUS "Downloading/updating ${DL_ARGS_PROJ}")
+    endif()
+
+    # Set up where we will put our temporary CMakeLists.txt file and also
+    # the base point below which the default source and binary dirs will be.
+    # The prefix must always be an absolute path.
+    if(NOT DL_ARGS_PREFIX)
+        set(DL_ARGS_PREFIX "${CMAKE_BINARY_DIR}")
+    else()
+        get_filename_component(DL_ARGS_PREFIX "${DL_ARGS_PREFIX}" ABSOLUTE
+            BASE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+    endif()
+    if(NOT DL_ARGS_DOWNLOAD_DIR)
+        set(DL_ARGS_DOWNLOAD_DIR "${DL_ARGS_PREFIX}/${DL_ARGS_PROJ}-download")
+    endif()
+
+    # Ensure the caller can know where to find the source and build directories
+    if(NOT DL_ARGS_SOURCE_DIR)
+        set(DL_ARGS_SOURCE_DIR "${DL_ARGS_PREFIX}/${DL_ARGS_PROJ}-src")
+    endif()
+    if(NOT DL_ARGS_BINARY_DIR)
+        set(DL_ARGS_BINARY_DIR "${DL_ARGS_PREFIX}/${DL_ARGS_PROJ}-build")
+    endif()
+    set(${DL_ARGS_PROJ}_SOURCE_DIR "${DL_ARGS_SOURCE_DIR}" PARENT_SCOPE)
+    set(${DL_ARGS_PROJ}_BINARY_DIR "${DL_ARGS_BINARY_DIR}" PARENT_SCOPE)
+
+    # The way that CLion manages multiple configurations, it causes a copy of
+    # the CMakeCache.txt to be copied across due to it not expecting there to
+    # be a project within a project.  This causes the hard-coded paths in the
+    # cache to be copied and builds to fail.  To mitigate this, we simply
+    # remove the cache if it exists before we configure the new project.  It
+    # is safe to do so because it will be re-generated.  Since this is only
+    # executed at the configure step, it should not cause additional builds or
+    # downloads.
+    file(REMOVE "${DL_ARGS_DOWNLOAD_DIR}/CMakeCache.txt")
+
+    # Create and build a separate CMake project to carry out the download.
+    # If we've already previously done these steps, they will not cause
+    # anything to be updated, so extra rebuilds of the project won't occur.
+    # Make sure to pass through CMAKE_MAKE_PROGRAM in case the main project
+    # has this set to something not findable on the PATH.
+    configure_file("${_DownloadProjectDir}/DownloadProject.CMakeLists.cmake.in"
+        "${DL_ARGS_DOWNLOAD_DIR}/CMakeLists.txt")
+    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}"
+        -D "CMAKE_MAKE_PROGRAM:FILE=${CMAKE_MAKE_PROGRAM}"
+        .
+        RESULT_VARIABLE result
+        ${OUTPUT_QUIET}
+        WORKING_DIRECTORY "${DL_ARGS_DOWNLOAD_DIR}"
+    )
+    if(result)
+        message(FATAL_ERROR "CMake step for ${DL_ARGS_PROJ} failed: ${result}")
+    endif()
+    execute_process(COMMAND ${CMAKE_COMMAND} --build .
+        RESULT_VARIABLE result
+        ${OUTPUT_QUIET}
+        WORKING_DIRECTORY "${DL_ARGS_DOWNLOAD_DIR}"
+    )
+    if(result)
+        message(FATAL_ERROR "Build step for ${DL_ARGS_PROJ} failed: ${result}")
+    endif()
+
+endfunction()

--- a/resources/build-appimages.sh
+++ b/resources/build-appimages.sh
@@ -44,9 +44,6 @@ cp -v "$REPO_ROOT"/resources/*.desktop AppDir/usr/share/applications/
 cp -v "$REPO_ROOT"/resources/*.svg AppDir/usr/share/icons/hicolor/scalable/apps/
 cp -v "$REPO_ROOT"/resources/*.xpm AppDir/resources/
 
-# bundle objdump required for parsing update information
-cp /usr/bin/objdump AppDir/usr/bin/
-
 # determine Git commit ID
 # linuxdeployqt uses this for naming the file
 export VERSION=$(cd "$REPO_ROOT" && git rev-parse --short HEAD)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,8 +22,17 @@ add_definitions("-DAPPIMAGEUPDATE_GIT_COMMIT=\"${GIT_COMMIT}\"")
 add_definitions("-DBUILD_DATE=\"${DATE}\"")
 add_definitions("-DBUILD_NUMBER=\"${BUILD_NUMBER}\"")
 
+
+# include ELF micro library
+add_subdirectory(elf)
+
+
 # core library
-add_library(libappimageupdate ${PROJECT_SOURCE_DIR}/include/appimage/update.h updater.cpp util.h)
+add_library(
+    libappimageupdate
+    ${PROJECT_SOURCE_DIR}/include/appimage/update.h updater.cpp
+    util.h
+)
 # since the target is called libsomething, one doesn't need CMake's additional lib prefix
 set_target_properties(libappimageupdate
     PROPERTIES
@@ -31,7 +40,7 @@ set_target_properties(libappimageupdate
     PUBLIC_HEADER ${PROJECT_SOURCE_DIR}/include/appimage/update.h
 )
 # link thread libraries
-target_link_libraries(libappimageupdate PRIVATE ${CMAKE_THREAD_LIBS_INIT} libzsync2 ${CPR_LIBRARIES})
+target_link_libraries(libappimageupdate PUBLIC elf PRIVATE ${CMAKE_THREAD_LIBS_INIT} libzsync2 ${CPR_LIBRARIES})
 # include directories, publicly
 target_include_directories(libappimageupdate PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/src/elf/CMakeLists.txt
+++ b/src/elf/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.2)
+
+# ELF library
+# extracted from AppImageKit source code
+# TODO: either turn this into a real library and use it in both projects,
+# or add a submodule/ExternalProject and build a library from it
+
+include(${PROJECT_SOURCE_DIR}/cmake/DownloadProject.cmake)
+
+download_project(
+    PROJ AppImageKit
+    PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
+    GIT_REPOSITORY https://github.com/AppImage/AppImageKit
+    GIT_TAG appimagetool/master
+    UPDATE_DISCONNECTED 1
+)
+
+set(SOURCE_DIR "${AppImageKit_SOURCE_DIR}/src/")
+
+
+add_library(
+    elf
+    STATIC
+    "${SOURCE_DIR}/light_elf.h" "${SOURCE_DIR}/light_byteswap.h" "${SOURCE_DIR}/elf.c" "${SOURCE_DIR}/elf.h"
+    "${SOURCE_DIR}/getsection.c" "${SOURCE_DIR}/getsection.h"
+)
+
+target_include_directories(elf PUBLIC
+    $<BUILD_INTERFACE:${AppImageKit_SOURCE_DIR}/src/>
+)

--- a/src/util.h
+++ b/src/util.h
@@ -164,5 +164,50 @@ namespace appimage {
                 exit(1);
             }
         }
-    };
-}
+
+        // Reads an ELF file section and returns its contents.
+        static std::string readElfSection(const std::string& filePath, const std::string& sectionName) {
+            // first of all, check whether there is an objdump binary next to the current one (probably
+            // the bundled one in the AppImages of AppImageUpdate), otherwise use the system wide
+            std::string objdump;
+
+            {
+                // TODO: replace this Linux specific solution with something platform independent
+                std::vector<char> buffer(4096);
+                readlink("/proc/self/exe", buffer.data(), buffer.size());
+
+                auto pathToBinary = std::string(buffer.data());
+                auto slashPos = pathToBinary.find_last_of('/');
+                auto bundledObjdump = pathToBinary.substr(0, slashPos) + "/objdump";
+
+                if (isFile(bundledObjdump)) {
+                    objdump = bundledObjdump;
+                } else {
+                    objdump = "objdump";
+                }
+            }
+
+            auto command = objdump + " -h \"" + filePath + "\"";
+
+            std::string match;
+            if (!callProgramAndGrepForLine(command, sectionName, match))
+                return "";
+
+            auto parts = split(match);
+            parts.erase(std::remove_if(parts.begin(), parts.end(),
+                [](std::string s) { return s.length() <= 0; }
+            ));
+
+            auto offset = (unsigned long) std::stoi(parts[5], nullptr, 16);
+            auto length = (unsigned long) std::stoi(parts[2], nullptr, 16);
+
+            std::ifstream ifs(filePath);
+
+            ifs.seekg(offset, std::ios::beg);
+            std::vector<char> rawUpdateInformation(length, '\0');
+            ifs.read(rawUpdateInformation.data(), length);
+
+            return rawUpdateInformation.data();
+        }
+    }; // namespace update
+} // namespace appimage


### PR DESCRIPTION
Implements changes suggested in #65. Downloads AppImageKit sources, builds a micro library from the ELF related code, and uses that library to read ELF sections.