### PR TITLE
Fix AppImageLauncher filesystem induced path bug

### DIFF
--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -637,16 +637,17 @@ namespace appimage {
             // initialize data class
             d = new Updater::Private();
 
+            // workaround for AppImageLauncher filesystem
+            d->pathToAppImage = ailfsRealpath(pathToAppImage);
+            d->overwrite = overwrite;
+
             // check whether file exists, otherwise throw exception
-            std::ifstream f(pathToAppImage);
+            std::ifstream f(d->pathToAppImage);
 
             if(!f || !f.good()) {
                 auto errorMessage = std::strerror(errno);
-                throw std::invalid_argument(errorMessage + std::string(": ") + pathToAppImage);
+                throw std::invalid_argument(errorMessage + std::string(": ") + d->pathToAppImage);
             }
-
-            d->pathToAppImage = pathToAppImage;
-            d->overwrite = overwrite;
         }
 
         Updater::~Updater() {


### PR DESCRIPTION
Workaround that does the job but relies on the map file output being somewhat stable. Should be replaced with a more reliable solution in the long term.

Fixes #131.