### PR TITLE
Fix initialization of QtUpdater::Private::enableRunUpdatedAppImageButton

### DIFF
--- a/src/qt-ui/qt-updater.cpp
+++ b/src/qt-ui/qt-updater.cpp
@@ -67,7 +67,8 @@ namespace appimage {
                                                                   spoilerLayout(nullptr),
                                                                   spoilerLog(nullptr),
                                                                   finished(false),
-                                                                  minimumWidth(400)
+                                                                  minimumWidth(400),
+                                                                  enableRunUpdatedAppImageButton(false)
                 {
                     if (!isFile(pathToAppImage.toStdString()))
                         throw std::runtime_error("No such file or directory: " + pathToAppImage.toStdString());


### PR DESCRIPTION
QtUpdater::Private::enableRunUpdatedAppImageButton is not initialized.
Therefore, display of the "Run updated AppImage" button is left to
chance.