### PR TITLE
Make the new appimage executable on validation success

### DIFF
--- a/include/appimage/update.h
+++ b/include/appimage/update.h
@@ -116,6 +116,9 @@ namespace appimage {
 
             // Restore original file, e.g., after a signature validation error
             bool restoreOriginalFile();
+
+            // copy permissions of the original AppImage to the new version
+            void copyPermissionsToNewFile();
         };
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -247,11 +247,20 @@ int main(const int argc, const char** argv) {
         return 1;
     }
 
-    if (validationResult >= Updater::VALIDATION_WARNING)
-        cerr << "Validation warning: " << Updater::signatureValidationMessage(validationResult) << endl;
+    if (validationResult >= Updater::VALIDATION_WARNING) {
+        if (validationResult == Updater::VALIDATION_NOT_SIGNED) {
+            // copy permissions of the old AppImage to the new version
+            updater.copyPermissionsToNewFile();
+        }
 
-    if (validationResult <= Updater::VALIDATION_WARNING)
+        cerr << "Validation warning: " << Updater::signatureValidationMessage(validationResult) << endl;
+    }
+
+    if (validationResult <= Updater::VALIDATION_WARNING) {
+        // copy permissions of the old AppImage to the new version
+        updater.copyPermissionsToNewFile();
         cerr << "Signature validation passed" << endl;
+    }
 
     if (removeOldFile) {
         if (isFile(oldFilePath)) {

--- a/src/qt-ui/qt-updater.cpp
+++ b/src/qt-ui/qt-updater.cpp
@@ -240,6 +240,11 @@ namespace appimage {
 
                         if (validationResult != d->updater->VALIDATION_PASSED) {
                             if (validationResult >= d->updater->VALIDATION_WARNING && validationResult < d->updater->VALIDATION_FAILED) {
+                                if (validationResult == d->updater->VALIDATION_NOT_SIGNED) {
+                                    // copy permissions of the old AppImage to the new version
+                                    d->updater->copyPermissionsToNewFile();
+                                }
+
                                 d->label->setText("Signature validation problem: " + validationMessage);
                                 palette.setColor(QPalette::Highlight, Qt::yellow);
                                 palette.setColor(QPalette::HighlightedText, Qt::black);
@@ -251,6 +256,9 @@ namespace appimage {
                                 QMessageBox::critical(this, "Error", message + "\n\nRestoring original file");
                             }
                         } else {
+                            // copy permissions of the old AppImage to the new version
+                            d->updater->copyPermissionsToNewFile();
+
                             if (validationResult == d->updater->VALIDATION_PASSED)
                                 newStatusMessage("Signature validation passed");
                             d->label->setText("Update successful!");

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -635,7 +635,7 @@ namespace appimage {
                 return false;
             }
         };
-        
+
         Updater::Updater(const std::string& pathToAppImage, bool overwrite) {
             // initialize data class
             d = new Updater::Private();
@@ -1086,6 +1086,21 @@ namespace appimage {
             if (oldFilePath == newFilePath) {
                 std::rename((newFilePath + ".zs-old").c_str(), newFilePath.c_str());
             }
+        }
+
+        void Updater::copyPermissionsToNewFile() {
+            std::string oldFilePath = abspath(d->pathToAppImage);
+
+            std::string newFilePath;
+
+            if (!pathToNewFile(newFilePath)) {
+                throw std::runtime_error("Failed to get path to new file");
+            }
+
+            // make sure to compare absolute, resolved paths
+            newFilePath = abspath(newFilePath);
+
+            appimage::update::copyPermissions(oldFilePath, newFilePath);
         }
     }
 }

--- a/src/util.h
+++ b/src/util.h
@@ -121,6 +121,25 @@ namespace appimage {
             return (bool) ifs && ifs.good();
         }
 
+        static void copyPermissions(const std::string& oldPath, const std::string& newPath) {
+            mode_t oldPerms;
+            auto errCode = zsync2::getPerms(oldPath, oldPerms);
+
+            if (errCode != 0) {
+                std::ostringstream ss;
+                ss << "Error calling stat(): " << strerror(errCode);
+#ifdef FLTK_UI
+                fl_message("%s", ss.str().c_str());
+#endif
+#ifdef QT_UI
+                QMessageBox::critical(nullptr, "Error", QString::fromStdString(ss.str()), QMessageBox::Close);
+#endif
+                exit(1);
+            }
+
+            chmod(newPath.c_str(), oldPerms);
+        }
+
         static void runApp(const std::string& path) {
             // make executable
             mode_t newPerms;


### PR DESCRIPTION
Currently, the 'Run' button functionality will make the newly downloaded AppImage executable before executing. What I propose with this pull request is that the newly downloaded AppImage is also made executable when signature validation passes (not on warning/missing signature).