### PR TITLE
Add missing dependencies to instruction

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -57,7 +57,7 @@ cat /etc/redhat-release
 wget http://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 rpm -ivh epel-release-latest-7.noarch.rpm
 
-yum install git cmake3 gcc-c++ curl-devel libX11-devel zlib-devel
+yum install git cmake3 gcc-c++ curl-devel libX11-devel zlib-devel fuse-devel librsvg2-devel cairo-devel
 
 git clone --recursive https://github.com/AppImage/AppImageUpdate
 cd AppImageUpdate/

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -15,7 +15,7 @@ This section describes how to build `libappimageupdate` and `libappimage` for co
 
 ```# Compile and install libappimageupdate
 
-sudo apt -y install wget git cmake g++ libcurl4-openssl-dev libx11-dev libz-dev
+sudo apt -y install wget git cmake g++ libcurl4-openssl-dev libx11-dev libz-dev libfuse-dev librsvg2-dev
 
 git clone --recursive https://github.com/AppImage/AppImageUpdate
 cd AppImageUpdate/


### PR DESCRIPTION
I tried to compile it on Ubuntu 20.04, but after command `cmake -DBUILD_QT_UI=OFF -DCMAKE_INSTALL_PREFIX=/usr ..` I got error:

```
-- Importing target librsvg via pkg-config (librsvg-2.0, shared)
-- Checking for module 'librsvg-2.0'
--   No package 'librsvg-2.0' found
CMake Error at /usr/share/cmake-3.16/Modules/FindPkgConfig.cmake:463 (message):
  A required package was not found
Call Stack (most recent call first):
  /usr/share/cmake-3.16/Modules/FindPkgConfig.cmake:643 (_pkg_check_modules_internal)
  lib/libappimage/cmake/scripts.cmake:113 (pkg_check_modules)
  lib/libappimage/cmake/imported_dependencies.cmake:11 (import_pkgconfig_target)
  lib/libappimage/cmake/dependencies.cmake:7 (include)
  lib/libappimage/CMakeLists.txt:29 (include)


and after installing librsvg2-dev

-- Checking for module 'librsvg-2.0'
--   Found librsvg-2.0, version 2.48.9
-- Downloading and building xz
-- Downloading and building squashfuse
-- Importing target libfuse via pkg-config (fuse, shared)
-- Checking for module 'fuse'
--   No package 'fuse' found
CMake Error at /usr/share/cmake-3.16/Modules/FindPkgConfig.cmake:463 (message):
  A required package was not found
Call Stack (most recent call first):
  /usr/share/cmake-3.16/Modules/FindPkgConfig.cmake:643 (_pkg_check_modules_internal)
  lib/libappimage/cmake/scripts.cmake:113 (pkg_check_modules)
  lib/libappimage/cmake/dependencies.cmake:64 (import_pkgconfig_target)
  lib/libappimage/CMakeLists.txt:29 (include)
```
Installing these two packages fixes this problem