### PR TITLE
use gpg instead of gpg2

### DIFF
--- a/include/appimage/update.h
+++ b/include/appimage/update.h
@@ -30,12 +30,12 @@ namespace appimage {
                 // warning states -- check like >= WARNING && < ERROR
                 VALIDATION_WARNING = 1000,
                 VALIDATION_NOT_SIGNED,
-                VALIDATION_GPG2_MISSING,
+                VALIDATION_GPG_MISSING,
 
                 // error states -- check like >= ERROR
                 VALIDATION_FAILED = 2000,
                 VALIDATION_KEY_CHANGED,
-                VALIDATION_GPG2_CALL_FAILED,
+                VALIDATION_GPG_CALL_FAILED,
                 VALIDATION_TEMPDIR_CREATION_FAILED,
                 VALIDATION_NO_LONGER_SIGNED,
                 VALIDATION_BAD_SIGNATURE,

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -900,10 +900,13 @@ namespace appimage {
             };
 
             // find gpg binary
-            auto gpgPath = findInPATH("gpg");
+            auto gpgPath = findInPATH("gpg2");
             if (gpgPath.empty()) {
-                cleanup();
-                return VALIDATION_GPG_MISSING;
+                gpgPath = findInPATH("gpg");
+                if (gpgPath.empty()) {
+                    cleanup();
+                    return VALIDATION_GPG_MISSING;
+                }
             }
 
             const auto tempKeyRingPath = tempDir + "/keyring";

--- a/src/updater.cpp
+++ b/src/updater.cpp
@@ -973,7 +973,7 @@ namespace appimage {
                     trim(line, '\n');
                     trim(line);
 
-                    d->issueStatusMessage(std::string("gpg: ") + line);
+                    d->issueStatusMessage(gpgPath + std::string(": ") + line);
 
                     auto splitOwner = [&line]() {
                         auto parts = split(line, '"');


### PR DESCRIPTION
Hi there :wave:,

TLDR:
This pretty simple PR would use the `gpg` command instead of `gpg2`. 

Reasoning:
Most, if not all distros have deprecated gpg v1 and the standard `gpg` package is now v2. gpg2 is currently a "dummy transitional package." and many distros do not install it by default, meaning extra user interaction is currently required to enable gpg signature validation of appimages. 

Research:
I checked quite a few distros and even the older supported ones like ubuntu 18.04 and centos 7 are using gpg v2 as the standard installed package, meaning I don't see any reason to continue using gpg2. 

This is somewhat in relation to https://github.com/AppImage/AppImageUpdate/issues/97