### PR TITLE
Revert "Require external packages only if they are dependencies of the generated binary"

### DIFF
--- a/cmake/AppImageUpdateConfig.cmake.in
+++ b/cmake/AppImageUpdateConfig.cmake.in
@@ -1,19 +1,8 @@
 @PACKAGE_INIT@
 
 # look up dependencies
-set(APPIMAGE_UPDATE_USE_SYSTEM_ZSYNC2 @USE_SYSTEM_ZSYNC2@)
-if(APPIMAGE_UPDATE_USE_SYSTEM_ZSYNC2)
-    find_package(zsync2 REQUIRED)
-endif()
-
-set(APPIMAGE_UPDATE_USE_SYSTEM_LIBAPPIMAGE @USE_SYSTEM_LIBAPPIMAGE@)
-if(APPIMAGE_UPDATE_USE_SYSTEM_LIBAPPIMAGE)
-    find_package(libappimage REQUIRED)
-endif()
-
-set(APPIMAGE_UPDATE_QT_UI @APPIMAGE_UPDATE_@BUILD_QT_UI@)
-if(APPIMAGE_UPDATE_QT_UI)
-    find_package(Qt5 REQUIRED COMPONENTS Core Widgets)
-endif()
+find_package(zsync2 REQUIRED)
+find_package(libappimage REQUIRED)
+find_package(Qt5 REQUIRED COMPONENTS Core Widgets)
 
 include("${CMAKE_CURRENT_LIST_DIR}/AppImageUpdateTargets.cmake")


### PR DESCRIPTION
Reverts AppImage/AppImageUpdate#195

There is at least one significant issue within that PR, and I was not allowed to review.