### PR TITLE
Made messages clearer when updating an unsigned AppImage

### DIFF
--- a/src/qt-ui/qt-updater.cpp
+++ b/src/qt-ui/qt-updater.cpp
@@ -246,7 +246,7 @@ namespace appimage {
                                 if (validationResult == d->updater->VALIDATION_NOT_SIGNED) {
                                     // copy permissions of the old AppImage to the new version
                                     d->updater->copyPermissionsToNewFile();
-                                    d->label->setText("Update Completed with warning: " + validationMessage);
+                                    d->label->setText("Update completed with warning: " + validationMessage);
                                     palette.setColor(QPalette::Highlight, Qt::gray);
                                     palette.setColor(QPalette::HighlightedText, Qt::black);
                                 } else {

--- a/src/qt-ui/qt-updater.cpp
+++ b/src/qt-ui/qt-updater.cpp
@@ -246,11 +246,14 @@ namespace appimage {
                                 if (validationResult == d->updater->VALIDATION_NOT_SIGNED) {
                                     // copy permissions of the old AppImage to the new version
                                     d->updater->copyPermissionsToNewFile();
+                                    d->label->setText("Update Completed with warning: " + validationMessage);
+                                    palette.setColor(QPalette::Highlight, Qt::gray);
+                                    palette.setColor(QPalette::HighlightedText, Qt::black);
+                                } else {
+                                    d->label->setText("Signature validation problem: " + validationMessage);
+                                    palette.setColor(QPalette::Highlight, Qt::yellow);
+                                    palette.setColor(QPalette::HighlightedText, Qt::black);
                                 }
-
-                                d->label->setText("Signature validation problem: " + validationMessage);
-                                palette.setColor(QPalette::Highlight, Qt::yellow);
-                                palette.setColor(QPalette::HighlightedText, Qt::black);
                             } else {
                                 d->updater->restoreOriginalFile();
                                 const QString message = "Signature validation error: " + validationMessage;


### PR DESCRIPTION
Made messaging clearer in the event of updating an unsigned AppImage in response to issue: https://github.com/AppImageCommunity/AppImageUpdate/issues/173